### PR TITLE
Fix duplicate RQ3

### DIFF
--- a/assignments.md
+++ b/assignments.md
@@ -17,7 +17,7 @@ For each review question, you are asked to answer a few questions about each lec
 * **Review questions 1:** regression and classification [[pdf](/assignments/review_questions1.pdf)]
 * **Review questions 2:** decision tree and feed-forward networks [[pdf](/assignments/review_questions2.pdf)]
 * **Review questions 3:** training feed-forward networks and CNNs [[pdf](/assignments/review_questions3.pdf)]
-* **Review questions 3:** RNNs and autoencoders [[pdf](/assignments/review_questions4.pdf)]
+* **Review questions 4:** RNNs and autoencoders [[pdf](/assignments/review_questions4.pdf)]
 <br>
 <hr>
 <br>


### PR DESCRIPTION
RQ4 was accidentally named RQ3. This commit renames it to the correct name.